### PR TITLE
Parse metadata only if it sent as text

### DIFF
--- a/Breeze.Client/Scripts/breeze.debug.js
+++ b/Breeze.Client/Scripts/breeze.debug.js
@@ -12365,7 +12365,7 @@ breeze.MergeStrategy = MergeStrategy;
             dataType: 'json',
             success: function(data, textStatus, XHR) {
                 
-                var metadata = JSON.parse(data);
+                var metadata = typeof data === "string" ? JSON.parse(data) : data;
                 if (!metadata) {
                     if (errorCallback) errorCallback(new Error("Metadata query failed for: " + metadataSvcUrl));
                     return;


### PR DESCRIPTION
Sending metadata as text adds a lot of overhead over the network (due " encoding) and on clientside due manual JSON.parse.
Your controller can simply return the Metadata as json by specifying the contentType header:

i.e. 

``` csharp
[HttpGet]
public HttpResponseMessage Metadata()
{
    var result = new HttpResponseMessage { Content = new StringContent(_contextProvider.Metadata())};
    result.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
    return result;
 }
```
