### PR TITLE
Set foreign key prop to its default value when navigation prop set to null

### DIFF
--- a/Breeze.Client/Scripts/IBlade/a35_defaultPropertyInterceptor.js
+++ b/Breeze.Client/Scripts/IBlade/a35_defaultPropertyInterceptor.js
@@ -159,8 +159,9 @@ function defaultPropertyInterceptor(property, newValue, rawAccessorFn) {
                 if (!entityAspect.entityState.isDeleted()) {
                     var inverseKeyProps = property.entityType.keyProperties;
                     inverseKeyProps.forEach(function(keyProp, i ) {
-                        var relatedValue = newValue ? newValue.getProperty(keyProp.name) : keyProp.defaultValue;
-                        that.setProperty(property.relatedDataProperties[i].name, relatedValue);
+                        var relatedDataProp = property.relatedDataProperties[i];
+                        var relatedValue = newValue ? newValue.getProperty(keyProp.name) : relatedDataProp.defaultValue;
+                        that.setProperty(relatedDataProp.name, relatedValue);
                     });
                 }
             }


### PR DESCRIPTION
This is to fix an error when setting a navigation property to null.

See http://stackoverflow.com/questions/15516046/breeze-js-setting-navigation-property-to-null-causes-foreign-key-error
