### PR TITLE
TempHire Sample .fin for IE8

### DIFF
--- a/Samples/TempHire/TempHire/App/viewmodels/dialog.js
+++ b/Samples/TempHire/TempHire/App/viewmodels/dialog.js
@@ -24,7 +24,7 @@
             ctor.prototype.canDeactivate = function (close) {
                 var self = this;
                 return this.content.canDeactivate(close)
-                    .finally(function() { self.content().dialogResult = null; });
+                    .fin(function() { self.content().dialogResult = null; });
             };
 
             ctor.prototype.deactivate = function(close) {

--- a/Samples/TempHire/TempHire/App/viewmodels/nameeditor.js
+++ b/Samples/TempHire/TempHire/App/viewmodels/nameeditor.js
@@ -26,7 +26,7 @@
                         self.lastName(data.lastName());
                     })
                     .fail(self.handleError)
-                    .finally(function() { ref.release(); });
+                    .fin(function() { ref.release(); });
             };
 
             ctor.prototype.canDeactivate = function (close) {


### PR DESCRIPTION
Editing a couple viewmodels to .fin from .finally to work in IE8. Found this in the Q.js Api as an alias [here](https://github.com/kriskowal/q/wiki/API-Reference). This is a really random change, but somehow ran across when having to deal with our project and figured I would try to fix it up.
