### PR TITLE
JSON.stringify spacer needs to be third parameter when using json2.js

### DIFF
--- a/Breeze.Client/Scripts/IBlade/a40_entityMetadata.js
+++ b/Breeze.Client/Scripts/IBlade/a40_entityMetadata.js
@@ -166,7 +166,7 @@ var MetadataStore = (function () {
             "dataServices": this.dataServices,
             "structuralTypes": __objectMapToArray(this._structuralTypeMap),
             "resourceEntityTypeMap": this._resourceEntityTypeMap
-        }, __config.stringifyPad);
+        }, null, __config.stringifyPad);
         return result;
     };
 

--- a/Breeze.Client/Scripts/breeze.base.debug.js
+++ b/Breeze.Client/Scripts/breeze.base.debug.js
@@ -5718,7 +5718,7 @@ var MetadataStore = (function () {
             "dataServices": this.dataServices,
             "structuralTypes": __objectMapToArray(this._structuralTypeMap),
             "resourceEntityTypeMap": this._resourceEntityTypeMap
-        }, __config.stringifyPad);
+        }, null, __config.stringifyPad);
         return result;
     };
 

--- a/Breeze.Client/Scripts/breeze.debug.js
+++ b/Breeze.Client/Scripts/breeze.debug.js
@@ -5718,7 +5718,7 @@ var MetadataStore = (function () {
             "dataServices": this.dataServices,
             "structuralTypes": __objectMapToArray(this._structuralTypeMap),
             "resourceEntityTypeMap": this._resourceEntityTypeMap
-        }, __config.stringifyPad);
+        }, null, __config.stringifyPad);
         return result;
     };
 


### PR DESCRIPTION
This fixes an error when Breeze's exportMetadata calls JSON.stringify when json2.js is used.

JSON.stringify syntax according to Mozilla is:

```
JSON.stringify(value[, replacer [, space]])
```

If you try to pass in `space` without also passing in `replacer`, I guess it works in most implementations, but json2.js for one will throw an error.

See also
http://stackoverflow.com/a/17342752/31563
