### PR TITLE
Added support for display name in DataProperty and NavigationProperty

### DIFF
--- a/Breeze.Client/Metadata/metadata.example.js
+++ b/Breeze.Client/Metadata/metadata.example.js
@@ -96,6 +96,7 @@ var x = {
               },
               {
                   "name": "categoryName",
+                  "displayName": "Category name",
                   "dataType": "String",
                   "isNullable": false,
                   "defaultValue": "",

--- a/Breeze.Client/Metadata/metadata.schema.js
+++ b/Breeze.Client/Metadata/metadata.schema.js
@@ -131,6 +131,10 @@ var x = {
                     "description": "The server side side name of this property. Either name or nameOnServer must be specified and either is sufficient.",
                     "type": "string"
                 },
+                "displayName": {
+                    "description": "The property display name. It is used for example in validation, replacing the %displayName% macro definition.",
+                    "type": "string"
+                },
                 "dataType": {
                     "description": "If present, the complexType name should be omitted.",
                     "enum": [
@@ -206,6 +210,10 @@ var x = {
                 },
                 "nameOnServer": {
                     "description": "The server side side name of this property. Either name or nameOnServer must be specified and either is sufficient.",
+                    "type": "string"
+                },
+                "displayName": {
+                    "description": "The property display name. It is used for example in validation, replacing the %displayName% macro definition.",
                     "type": "string"
                 },
                 "entityTypeName": {

--- a/Breeze.Client/Scripts/IBlade/a40_entityMetadata.js
+++ b/Breeze.Client/Scripts/IBlade/a40_entityMetadata.js
@@ -2044,6 +2044,7 @@ var DataProperty = (function () {
     @param [config.nameOnServer] {String} Same as above but the name is that defined on the server.
     Either this or the 'name' above must be specified. Whichever one is specified the other will be computed using
     the NamingConvention on the MetadataStore associated with the EntityType to which this will be added.
+    @param [config.displayName] {String}
     @param [config.dataType=DataType.String] {DataType}
     @param [config.complexTypeName] {String}
     @param [config.isNullable=true] {Boolean}
@@ -2058,6 +2059,7 @@ var DataProperty = (function () {
         assertConfig(config)
             .whereParam("name").isString().isOptional()
             .whereParam("nameOnServer").isString().isOptional()
+            .whereParam("displayName").isString().isOptional()
             .whereParam("dataType").isEnumOf(DataType).isOptional().or().isString().or().isInstanceOf(ComplexType)
             .whereParam("complexTypeName").isOptional()
             .whereParam("isNullable").isBoolean().isOptional().withDefault(true)
@@ -2302,6 +2304,7 @@ var NavigationProperty = (function () {
     @param [config.nameOnServer] {String} Same as above but the name is that defined on the server.
     Either this or the 'name' above must be specified. Whichever one is specified the other will be computed using
     the NamingConvention on the MetadataStore associated with the EntityType to which this will be added.
+    @param [config.displayName] {String}
     @param config.entityTypeName {String} The fully qualified name of the type of entity that this property will return.  This type
     need not yet have been created, but it will need to get added to the relevant MetadataStore before this EntityType will be 'complete'.
     The entityType name is constructed as: {shortName} + ":#" + {namespace}
@@ -2318,6 +2321,7 @@ var NavigationProperty = (function () {
         assertConfig(config)
             .whereParam("name").isString().isOptional()
             .whereParam("nameOnServer").isString().isOptional()
+            .whereParam("displayName").isString().isOptional()
             .whereParam("entityTypeName").isString()
             .whereParam("isScalar").isBoolean()
             .whereParam("associationName").isString().isOptional()


### PR DESCRIPTION
Hi,
I found some hints in the internet (stackoverflow & co) that in order to have the %displayName% replaced in the validation messages with a proper display name, one should set the displayName field in the DataProperty. I thought that this information could be sent from the server anyway, so why not include it in the metadata already. I did this on my test machine and it works pretty well. I was wondering, though, if we could also send custom metadata from server, like field description and watermark. I understand that this is custom code, but it could be very helpful to allow also setting such fields.

Regards,
Ioan
