### PR TITLE
added check for assignFn in processMeta

### DIFF
--- a/Breeze.Client/Scripts/breeze.base.debug.js
+++ b/Breeze.Client/Scripts/breeze.base.debug.js
@@ -13461,7 +13461,7 @@ var EntityManager = (function () {
             return null;
         } else if (meta.nodeRefId) {
             var refValue = resolveRefEntity(meta.nodeRefId, mappingContext);
-            if (typeof refValue === "function") {
+            if (typeof refValue === "function" && assignFn != null) {
                 mappingContext.deferredFns.push(function () {
                     assignFn(refValue);
                 });


### PR DESCRIPTION
Sorry if this isn't how pull requests are supposed to be done, I couldn't find any information on it.

I was having a crash when using a custom JsonResultsAdapter that had an array of nodeRef's as one of the entity's navigationProperties. The corresponding nodes were defined further down in the data, so they did not exist in the refMap, which caused resolveRefEntity to return a function in processMeta, however assignFn was not set and so the deferredFn caused an error when it tried to execute the line "assignFn(refValue);" (line 13466).

I noticed that mergeRelatedEntities already handles the case that the relatedEntitiy returned from visitAndMerge is a function (deferred when the refMap id is not found), so adding a check that assignFn is not null and then returning the refValue function in processMeta causes the refValue function to be called at the relationship updated in mergeRelatedEntities.

I'm not sure if this affects any other code that relies on processMeta, but it seems to have fixed the issue for me.
