### PR TITLE
Edited odata webservice to let savechanges work for Odata Webapi of MVC5

### DIFF
--- a/Breeze.Client/Scripts/IBlade/b00_breeze.dataService.odata.js
+++ b/Breeze.Client/Scripts/IBlade/b00_breeze.dataService.odata.js
@@ -211,7 +211,7 @@
 
     function updateDeleteMergeRequest(request, aspect, prefix) {
         var extraMetadata = aspect.extraMetadata;
-        var uri = extraMetadata.uri;
+        var uri = extraMetadata.uri || extraMetadata.id;
         if (__stringStartsWith(uri, prefix)) {
             uri = uri.substring(prefix.length);
         }


### PR DESCRIPTION
Edited odata webservice to let savechanges work for Odata Webapi of MVC5 RC1

Webapi Odata misses some odata features in the metadata. This will be fixed in the final release of MVC5. But for working with breeze now it misses the extrametadata.uri property. But the extrametadata.id is populated properly.
