### PR TITLE
Fixed URIs used in OData batch queries

### DIFF
--- a/Breeze.Client/Scripts/IBlade/b00_breeze.dataService.odata.js
+++ b/Breeze.Client/Scripts/IBlade/b00_breeze.dataService.odata.js
@@ -203,7 +203,7 @@
             var request = { headers: { "Content-ID": id, "DataServiceVersion": "2.0" } };
             contentKeys[id] = entity;
             if (aspect.entityState.isAdded()) {
-                request.requestUri = entity.entityType.defaultResourceName;
+                request.requestUri = prefix + entity.entityType.defaultResourceName;
                 request.method = "POST";
                 request.data = helper.unwrapInstance(entity, true);
                 tempKeys[id] = aspect.getKey();
@@ -233,9 +233,6 @@
     function updateDeleteMergeRequest(request, aspect, prefix) {
         var extraMetadata = aspect.extraMetadata;
         var uri = extraMetadata.uri || extraMetadata.id;
-        if (__stringStartsWith(uri, prefix)) {
-            uri = uri.substring(prefix.length);
-        }
         request.requestUri = uri;
         if (extraMetadata.etag) {
             request.headers["If-Match"] = extraMetadata.etag;


### PR DESCRIPTION
In OData batch requests, the current implementation does not include the service prefix part of the URI, which causes the OData service to return a 404 for the individual operations of the changeset (the overall batch request returns a 202 though). For example, for a service at `http://localhost:1234/odata`, invoking `saveChanges()` for a batch that includes one insert sends the following multipart requerst:

```
--batch_e3f8-a5e8-e8cc
Content-Type: multipart/mixed; boundary=changeset_f02f-91e5-10d3

--changeset_f02f-91e5-10d3
Content-Type: application/http
Content-Transfer-Encoding: binary

POST Topics HTTP/1.1
Content-ID: 1
DataServiceVersion: 2.0
Accept: application/atomsvc+xml;q=0.8, application/json;odata=fullmetadata;q=0.7, application/json;q=0.5, */*;q=0.1
Content-Type: application/json
MaxDataServiceVersion: 3.0

{"Name":"New Topic"}
--changeset_f02f-91e5-10d3--

--batch_e3f8-a5e8-e8cc--
```

Notice how the POST uri is incorrectly specified as `Topics`, while it should be `/odata/Topics` (or `http://localhost:1234/odata/Topics`).

The case for POST requests was first reported in [1], But MERGE/PATCH requests are affected as well.

[1] http://stackoverflow.com/questions/18813890/post-batch-request-with-breezejs
