### PR TITLE
Added default 'noTrackingEnabled' query option to ctor and added property to clone list

### DIFF
--- a/Breeze.Client/Scripts/IBlade/a45_entityQuery.js
+++ b/Breeze.Client/Scripts/IBlade/a45_entityQuery.js
@@ -34,6 +34,7 @@ var EntityQuery = (function () {
         this.expandClause = null;
         this.parameters = {};
         this.inlineCountEnabled = false;
+        this.noTrackingEnabled = false;
         // default is to get queryOptions and dataService from the entityManager.
         // this.queryOptions = new QueryOptions();
         // this.dataService = new DataService();
@@ -807,6 +808,7 @@ var EntityQuery = (function () {
             "takeCount",
             "expandClause",
             "inlineCountEnabled",
+            "noTrackingEnabled",
             "queryOptions", 
             "entityManager",
             "dataService",


### PR DESCRIPTION
"noTrackingEnabled" query option is not cloned to new query when other method (e.g. using()) is called after noTracking() method

E.g.

var query = breeze.EntityQuery.from('Resource')
  .noTracking()
  .using(breeze.FetchStrategy.FromServer)
