### PR TITLE
a40_entityMetadata.js/a45_entityQuery.js Allow property paths with subtype

### DIFF
--- a/Breeze.Client/Scripts/IBlade/a45_entityQuery.js
+++ b/Breeze.Client/Scripts/IBlade/a45_entityQuery.js
@@ -1035,7 +1035,7 @@ var QueryFuncs = (function() {
     
 var FnNode = (function() {
     // valid property name identifier
-    var RX_IDENTIFIER = /^[a-z_][\w.$]*$/i ;
+    var RX_IDENTIFIER = /^[a-z_](?:\/?[\w.$])*$/i ;
     // comma delimited expressions ignoring commas inside of quotes.
     var RX_COMMA_DELIM1 = /('[^']*'|[^,]+)/g ;
     var RX_COMMA_DELIM2 = /("[^"]*"|[^,]+)/g ;


### PR DESCRIPTION
OData 3 supports filtering on subtypes by using syntax such as follows:
Order/Northwind.Models.InternationalOrder/ExciseTax

This change allows for this type of filtering.

Original request:
https://breezejs.uservoice.com/forums/173093-breeze-feature-suggestions/suggestions/5655259-support-filters-for-multi-level-relationships-with
